### PR TITLE
Take two on status setting

### DIFF
--- a/src/main/java/gov/acwi/wqp/etl/Application.java
+++ b/src/main/java/gov/acwi/wqp/etl/Application.java
@@ -55,9 +55,9 @@ public class Application implements CommandLineRunner {
 			jobExecution = reStartJob();
 		}
 		if (null == jobExecution 
-				|| ExitStatus.UNKNOWN.equals(jobExecution.getExitStatus())
-				|| ExitStatus.FAILED.equals(jobExecution.getExitStatus())
-				|| ExitStatus.STOPPED.equals(jobExecution.getExitStatus())) {
+				|| ExitStatus.UNKNOWN.getExitCode().contentEquals(jobExecution.getExitStatus().getExitCode())
+				|| ExitStatus.FAILED.getExitCode().contentEquals(jobExecution.getExitStatus().getExitCode())
+				|| ExitStatus.STOPPED.getExitCode().contentEquals(jobExecution.getExitStatus().getExitCode())) {
 			throw new RuntimeException("Job did not complete as planned.");
 		}
 	}


### PR DESCRIPTION
Turns out the exit status is an object in which the message may change, causing it to not equals the constant without a message.